### PR TITLE
Prepare for cross-publishing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,3 +17,8 @@ cache:
     - $HOME/.sbt
 
 script: sbt ++$TRAVIS_SCALA_VERSION test
+
+env:
+  matrix:
+    - SCALAJS_VERSION="0.6.32"
+    - SCALAJS_VERSION="1.0.0"

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,8 @@
 organization in ThisBuild := "net.exoego"
 val projectName = "scalajs-test-helper"
 
+val scalatestVersion = "3.1.1"
+
 lazy val root = project
   .in(file("."))
   .settings(
@@ -19,7 +21,7 @@ lazy val core = project
     MySettings.commonSettings,
     MySettings.publishingSettings,
     libraryDependencies ++= Seq(
-      "org.scalatest" %%% "scalatest" % "3.1.0" % Test
+      "org.scalatest" %%% "scalatest" % scalatestVersion % Test
     )
   )
 
@@ -31,7 +33,7 @@ lazy val forScalaTest = project
     MySettings.commonSettings,
     MySettings.publishingSettings,
     libraryDependencies ++= Seq(
-      "org.scalatest" %%% "scalatest" % "3.1.0" % Compile
+      "org.scalatest" %%% "scalatest" % scalatestVersion % Compile
     )
   )
   .dependsOn(core)

--- a/project/MySettings.scala
+++ b/project/MySettings.scala
@@ -43,12 +43,14 @@ object MySettings {
   lazy val commonSettings = Seq(
     autoCompilerPlugins := true,
     scalacOptions ++= Seq(
-      "-P:scalajs:sjsDefinedByDefault",
       "-deprecation",
       "-unchecked",
       "-feature",
       "-language:implicitConversions"
     ) ++ lintSettings.value,
+    scalacOptions ++= Seq("-P:scalajs:sjsDefinedByDefault").filter { _ =>
+      Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.0.0").startsWith("0.6.")
+    },
     scalacOptions in Compile in compile ++= Seq(
       "-Xfatal-warnings"
     ),

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 val scalaJSVersion =
-  Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.32")
+  Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.0.0")
 
 addSbtPlugin("com.dwijnand" % "sbt-travisci" % "1.2.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.3.1")

--- a/release.sh
+++ b/release.sh
@@ -1,0 +1,6 @@
+#! /bin/bash
+
+export SCALAJS_VERSION=0.6.32
+sbt clean +test +publishSigned sonatypeBundleUpload sonatypeReleaseAll
+export SCALAJS_VERSION=1.0.0
+sbt clean +test +publishSigned sonatypeBundleUpload sonatypeReleaseAll


### PR DESCRIPTION
Waiting Scala.js `1.0.0` to use `js.Object.entries` (not avialable in `1.0.0-RC2`)