### PR TITLE
Mergify: configuration update

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -2,7 +2,7 @@ pull_request_rules:
   - name: Automatic merge on approval
     conditions:
       - "author=scala-steward"
-      - "check-success~=CI"
+      - "#status-success>=3"
     actions:
       merge:
         method: merge


### PR DESCRIPTION
This change has been made by @exoego from https://mergify.io config editor.


According to https://docs.mergify.io/conditions.html#about-status-checks, `check-succes~=FOO` is discouraged.

> check-success~=build while expecting this to wait for all status checks that have build in their name (see point 1. above).
